### PR TITLE
fix(request-validation): Do not write content to upstream if empty

### DIFF
--- a/src/main/java/io/gravitee/policy/requestvalidation/RequestValidationPolicy.java
+++ b/src/main/java/io/gravitee/policy/requestvalidation/RequestValidationPolicy.java
@@ -124,7 +124,10 @@ public class RequestValidationPolicy {
                                         .put("violations", messageViolations)
                                         .build()));
                     } else {
-                        super.write(buffer);
+                        if (buffer.length() > 0) {
+                            super.write(buffer);
+                        }
+
                         super.end();
                     }
                 }


### PR DESCRIPTION
Closes gravitee-io/issues#2833