### PR TITLE
Properly return a constraint violation in case of malformed input

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,14 +1,25 @@
 {
-  "extends": [
-    "config:base",
-    "schedule:earlyMondays"
-  ],
-  "prConcurrentLimit": 3,
+  "extends": ["config:base"],
   "rebaseWhen": "conflicted",
   "packageRules": [
     {
       "matchDatasources": ["orb"],
-      "rangeStrategy": "replace"
+      "matchUpdateTypes": ["patch", "minor"],
+      "automerge": true,
+      "automergeType": "branch",
+      "semanticCommitType": "ci"
+    },
+    {
+      "matchDepTypes": ["provided", "test", "build", "import", "parent"],
+      "matchUpdateTypes": ["patch", "minor"],
+      "automerge": true,
+      "automergeType": "branch",
+      "semanticCommitType": "chore"
+    },
+    {
+      "matchDepTypes": ["provided", "test", "build", "import", "parent"],
+      "matchUpdateTypes": ["major"],
+      "semanticCommitType": "chore"
     }
   ]
 }

--- a/pom.xml
+++ b/pom.xml
@@ -123,14 +123,26 @@
 
         <!-- Test scope -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -30,16 +30,16 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>20.0</version>
+        <version>21.0.0</version>
     </parent>
 
     <properties>
-        <gravitee-bom.version>1.0</gravitee-bom.version>
-        <gravitee-gateway-api.version>1.31.0</gravitee-gateway-api.version>
-        <gravitee-expression-language.version>1.8.0</gravitee-expression-language.version>
-        <gravitee-policy-api.version>1.10.0</gravitee-policy-api.version>
-        <gravitee-common.version>1.18.0</gravitee-common.version>
-        <swagger-parser.version>2.0.14</swagger-parser.version>
+        <gravitee-bom.version>4.0.3</gravitee-bom.version>
+        <gravitee-gateway-api.version>2.0.1</gravitee-gateway-api.version>
+        <gravitee-expression-language.version>2.0.1</gravitee-expression-language.version>
+        <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
+        <gravitee-common.version>2.1.0</gravitee-common.version>
+        <swagger-parser.version>2.1.11</swagger-parser.version>
 
         <maven-assembly-plugin.version>3.5.0</maven-assembly-plugin.version>
         <prettier-maven-plugin.version>0.19</prettier-maven-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,10 @@
         <gravitee-common.version>1.18.0</gravitee-common.version>
         <swagger-parser.version>2.0.14</swagger-parser.version>
 
-        <maven-assembly-plugin.version>2.5.5</maven-assembly-plugin.version>
+        <maven-assembly-plugin.version>3.5.0</maven-assembly-plugin.version>
+        <prettier-maven-plugin.version>0.19</prettier-maven-plugin.version>
+        <properties-maven-plugin.version>1.1.0</properties-maven-plugin.version>
+
         <!-- Property used by the publication job in CI-->
         <publish-folder-path>graviteeio-apim/plugins/policies</publish-folder-path>
     </properties>
@@ -143,7 +146,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>properties-maven-plugin</artifactId>
-                <version>1.0.0</version>
+                <version>${properties-maven-plugin.version}</version>
                 <executions>
                     <execution>
                         <phase>initialize</phase>
@@ -182,10 +185,9 @@
             <plugin>
                 <groupId>com.hubspot.maven.plugins</groupId>
                 <artifactId>prettier-maven-plugin</artifactId>
-                <version>0.17</version>
+                <version>${prettier-maven-plugin.version}</version>
                 <configuration>
-                    <nodeVersion>12.13.0</nodeVersion>
-                    <prettierJavaVersion>1.6.1</prettierJavaVersion>
+                    <prettierJavaVersion>2.1.0</prettierJavaVersion>
                 </configuration>
                 <executions>
                     <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,7 @@
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
         <gravitee-common.version>2.1.0</gravitee-common.version>
         <swagger-parser.version>2.1.11</swagger-parser.version>
+        <gravitee-gateway.version>3.20.3</gravitee-gateway.version>
 
         <maven-assembly-plugin.version>3.5.0</maven-assembly-plugin.version>
         <prettier-maven-plugin.version>0.19</prettier-maven-plugin.version>
@@ -143,6 +144,13 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.gravitee.apim.gateway</groupId>
+            <artifactId>gravitee-apim-gateway-tests-sdk</artifactId>
+            <version>${gravitee-gateway.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/test/java/io/gravitee/policy/requestvalidation/RequestValidationPolicyIntegrationTest.java
+++ b/src/test/java/io/gravitee/policy/requestvalidation/RequestValidationPolicyIntegrationTest.java
@@ -1,0 +1,157 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.policy.requestvalidation;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.apim.gateway.tests.sdk.AbstractPolicyTest;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.policy.requestvalidation.configuration.RequestValidationPolicyConfiguration;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.json.JsonObject;
+import io.vertx.rxjava3.core.http.HttpClient;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@GatewayTest
+class RequestValidationPolicyIntegrationTest extends AbstractPolicyTest<RequestValidationPolicy, RequestValidationPolicyConfiguration> {
+
+    @Test
+    @DisplayName("Should validate request body")
+    @DeployApi("/apis/api-with-a-simple-constraint.json")
+    void shouldValidateRequestBody(HttpClient httpClient) throws InterruptedException {
+        wiremock.stubFor(post("/endpoint").willReturn(ok()));
+
+        String requestBody = new JsonObject().put("firstName", "Gaëtan").toString();
+
+        httpClient
+            .rxRequest(HttpMethod.POST, "/test")
+            .flatMap(httpClientRequest -> httpClientRequest.rxSend(requestBody))
+            .test()
+            .await()
+            .assertComplete()
+            .assertValue(response -> {
+                assertThat(response.statusCode()).isEqualTo(200);
+                return true;
+            })
+            .assertNoErrors();
+
+        wiremock.verify(postRequestedFor(urlPathEqualTo("/endpoint")).withRequestBody(equalTo(requestBody)));
+    }
+
+    @Test
+    @DisplayName("Should return 400 with an error message when request body is invalid")
+    @DeployApi("/apis/api-with-a-simple-constraint.json")
+    void shouldReturn400WhenRequestBodyIsInvalid(HttpClient httpClient) throws InterruptedException {
+        wiremock.stubFor(post("/endpoint").willReturn(ok()));
+
+        String requestBody = new JsonObject().put("AnotherKey", "Gaëtan").toString();
+
+        httpClient
+            .rxRequest(HttpMethod.POST, "/test")
+            .flatMap(httpClientRequest -> httpClientRequest.rxSend(requestBody))
+            .flatMapPublisher(response -> {
+                assertThat(response.statusCode()).isEqualTo(400);
+                return response.toFlowable();
+            })
+            .test()
+            .await()
+            .assertComplete()
+            .assertValue(bufferBody -> {
+                JsonObject body = new JsonObject(bufferBody.toString());
+                assertThat(body.getString("message")).isEqualTo("Request is not valid according to constraint rules");
+                assertThat(body.getJsonArray("constraints").size()).isEqualTo(1);
+                assertThat(body.getJsonArray("constraints").getString(0)).isEqualTo("Missing firstName");
+                return true;
+            })
+            .assertNoErrors();
+
+        wiremock.verify(0, postRequestedFor(urlPathEqualTo("/endpoint")));
+    }
+
+    @Test
+    @DisplayName("Should return 400 with multiple error messages when multiple constraints are violated")
+    @DeployApi("/apis/api-with-multiple-constraints.json")
+    void shouldReturn400WhenMultipleConstraintsAreViolated(HttpClient httpClient) throws InterruptedException {
+        wiremock.stubFor(post("/endpoint").willReturn(ok()));
+
+        String requestBody = new JsonObject()
+            .put("AnotherKey", "Gaëtan")
+            .put("job", "MANAGER")
+            .put("age", 18)
+            .put("email", "an Invalid Email")
+            .toString();
+
+        httpClient
+            .rxRequest(HttpMethod.POST, "/test")
+            .flatMap(httpClientRequest -> httpClientRequest.rxSend(requestBody))
+            .flatMapPublisher(response -> {
+                assertThat(response.statusCode()).isEqualTo(400);
+                return response.toFlowable();
+            })
+            .test()
+            .await()
+            .assertComplete()
+            .assertValue(bufferBody -> {
+                JsonObject body = new JsonObject(bufferBody.toString());
+                assertThat(body.getString("message")).isEqualTo("Request is not valid according to constraint rules");
+                assertThat(body.getJsonArray("constraints").size()).isEqualTo(4);
+                assertThat(body.getJsonArray("constraints").getString(0)).isEqualTo("Missing firstName");
+                assertThat(body.getJsonArray("constraints").getString(1)).isEqualTo("Invalid job, must be one of `DEV`, `OPS` or `QA`");
+                assertThat(body.getJsonArray("constraints").getString(2)).isEqualTo("Invalid age, must be greater than 20");
+                assertThat(body.getJsonArray("constraints").getString(3)).isEqualTo("an Invalid Email is not a valid email.");
+                return true;
+            })
+            .assertNoErrors();
+
+        wiremock.verify(0, postRequestedFor(urlPathEqualTo("/endpoint")));
+    }
+
+    @Test
+    @DisplayName("Should return 400 with an error message when request body is malformed")
+    @DeployApi("/apis/api-with-a-simple-constraint.json")
+    void shouldReturn400WhenRequestBodyIsMalformed(HttpClient httpClient) throws InterruptedException {
+        wiremock.stubFor(post("/endpoint").willReturn(ok()));
+
+        String requestBody = "{\n" + "\"field1\": \"value\"\n" + "\"field2\": \"value\"\n" + "}";
+
+        httpClient
+            .rxRequest(HttpMethod.POST, "/test")
+            .flatMap(httpClientRequest -> httpClientRequest.rxSend(requestBody))
+            .flatMapPublisher(response -> {
+                assertThat(response.statusCode()).isEqualTo(400);
+                return response.toFlowable();
+            })
+            .test()
+            .await()
+            .assertComplete()
+            .assertValue(bufferBody -> {
+                JsonObject body = new JsonObject(bufferBody.toString());
+                assertThat(body.getString("message")).isEqualTo("Request is not valid according to constraint rules");
+                assertThat(body.getJsonArray("constraints").size()).isEqualTo(1);
+                assertThat(body.getJsonArray("constraints").getString(0))
+                    .isEqualTo(
+                        "Unable to evaluate expression: {#jsonPath(#request.content, '$.firstName')} -> It might be related to an invalid request body"
+                    );
+                return true;
+            })
+            .assertNoErrors();
+
+        wiremock.verify(0, postRequestedFor(urlPathEqualTo("/endpoint")));
+    }
+}

--- a/src/test/java/io/gravitee/policy/requestvalidation/RequestValidationPolicyTest.java
+++ b/src/test/java/io/gravitee/policy/requestvalidation/RequestValidationPolicyTest.java
@@ -15,7 +15,6 @@
  */
 package io.gravitee.policy.requestvalidation;
 
-import static org.mockito.Matchers.argThat;
 import static org.mockito.Mockito.*;
 
 import io.gravitee.common.http.HttpStatusCode;

--- a/src/test/java/io/gravitee/policy/requestvalidation/RequestValidationPolicyTest.java
+++ b/src/test/java/io/gravitee/policy/requestvalidation/RequestValidationPolicyTest.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.policy.requestvalidation;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
 import io.gravitee.common.http.HttpStatusCode;
@@ -30,19 +31,14 @@ import io.gravitee.policy.requestvalidation.configuration.RequestValidationPolic
 import io.gravitee.policy.requestvalidation.validator.*;
 import java.util.*;
 import java.util.regex.Pattern;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-/**
- * @author David BRASSELY (david.brassely at graviteesource.com)
- * @author GraviteeSource Team
- */
-@RunWith(MockitoJUnitRunner.class)
-public class RequestValidationPolicyTest {
+@ExtendWith(MockitoExtension.class)
+class RequestValidationPolicyTest {
 
     private RequestValidationPolicy policy;
 
@@ -61,14 +57,14 @@ public class RequestValidationPolicyTest {
     @Mock
     protected ExecutionContext executionContext;
 
-    @Before
-    public void init() {
+    @BeforeEach
+    void init() {
         policy = new RequestValidationPolicy(configuration);
-        when(configuration.getStatus()).thenReturn(HttpStatusCode.BAD_REQUEST_400);
+        lenient().when(configuration.getStatus()).thenReturn(HttpStatusCode.BAD_REQUEST_400);
     }
 
     @Test
-    public void shouldValidateQueryParameter() {
+    void shouldValidateQueryParameter() {
         // Prepare inbound request
         MultiValueMap<String, String> parameters = mock(MultiValueMap.class);
         when(parameters.get("my-param")).thenReturn(Collections.singletonList("my-value"));
@@ -97,7 +93,7 @@ public class RequestValidationPolicyTest {
     }
 
     @Test
-    public void shouldNotValidateQueryParameter_notNull() {
+    void shouldNotValidateQueryParameter_notNull() {
         // Prepare inbound request
         MultiValueMap<String, String> parameters = mock(MultiValueMap.class);
         when(request.parameters()).thenReturn(parameters);
@@ -125,7 +121,7 @@ public class RequestValidationPolicyTest {
     }
 
     @Test
-    public void shouldNotValidateQueryParameter_invalidMinConstraint() {
+    void shouldNotValidateQueryParameter_invalidMinConstraint() {
         // Prepare inbound request
         MultiValueMap<String, String> parameters = mock(MultiValueMap.class);
         when(request.parameters()).thenReturn(parameters);
@@ -154,7 +150,7 @@ public class RequestValidationPolicyTest {
     }
 
     @Test
-    public void shouldValidateQueryParameter_multipleRules() {
+    void shouldValidateQueryParameter_multipleRules() {
         // Prepare inbound request
         MultiValueMap<String, String> parameters = mock(MultiValueMap.class);
         when(parameters.get("my-param")).thenReturn(Collections.singletonList("80"));
@@ -196,7 +192,7 @@ public class RequestValidationPolicyTest {
     }
 
     @Test
-    public void shouldValidatePathParameter_el_Rule() {
+    void shouldValidatePathParameter_el_Rule() {
         // Prepare inbound request
         when(request.pathInfo()).thenReturn("/fr");
 
@@ -224,7 +220,7 @@ public class RequestValidationPolicyTest {
     }
 
     @Test
-    public void shouldValidateQueryParameter_RuleWithParamsContainsNull() {
+    void shouldValidateQueryParameter_RuleWithParamsContainsNull() {
         // Prepare inbound request
         MultiValueMap<String, String> parameters = mock(MultiValueMap.class);
         when(parameters.get("my-param")).thenReturn(Collections.singletonList("80"));
@@ -253,7 +249,7 @@ public class RequestValidationPolicyTest {
         verify(policyChain).doNext(request, response);
     }
 
-    public Rule prepareRule(String input, String[] params, ConstraintType constraintType) {
+    Rule prepareRule(String input, String[] params, ConstraintType constraintType) {
         Rule rule = new Rule();
         rule.setInput(input);
         Constraint constraint = new Constraint();
@@ -264,7 +260,7 @@ public class RequestValidationPolicyTest {
     }
 
     @Test
-    public void shouldValidateTheOrderOfViolationsWhenUsingMultipleRules() {
+    void shouldValidateTheOrderOfViolationsWhenUsingMultipleRules() {
         final String RULE_VALUE = "{#request.headers['my-header']}";
         final String PATTERN = "^[0-9a-fA-F]{32}\\z";
 
@@ -316,7 +312,7 @@ public class RequestValidationPolicyTest {
                         .forEach(ruleMapEntry -> {
                             ConstraintValidator validator = ruleMapEntry.getValue();
                             String violation = violations.pollFirst();
-                            Assert.assertTrue(Pattern.matches(validatorRegexMap.get(validator.getClass()), violation));
+                            assertThat(Pattern.matches(validatorRegexMap.get(validator.getClass()), violation)).isTrue();
                         });
 
                     return result.statusCode() == HttpStatusCode.BAD_REQUEST_400;
@@ -325,7 +321,7 @@ public class RequestValidationPolicyTest {
     }
 
     @Test
-    public void shouldValidateQueryParameter_NotRequiredAndNotPresent() {
+    void shouldValidateQueryParameter_NotRequiredAndNotPresent() {
         // Prepare inbound request
         when(request.parameters()).thenReturn(mock(MultiValueMap.class));
 
@@ -355,7 +351,7 @@ public class RequestValidationPolicyTest {
     }
 
     @Test
-    public void shouldNotValidateQueryParameter_RequiredAndNotPresent() {
+    void shouldNotValidateQueryParameter_RequiredAndNotPresent() {
         // Prepare inbound request
         when(request.parameters()).thenReturn(mock(MultiValueMap.class));
 
@@ -385,7 +381,7 @@ public class RequestValidationPolicyTest {
     }
 
     @Test
-    public void shouldValidateQueryParameter_ValidPatternNotRequiredAndPresent() {
+    void shouldValidateQueryParameter_ValidPatternNotRequiredAndPresent() {
         // Prepare inbound request
         MultiValueMap<String, String> parameters = mock(MultiValueMap.class);
         when(parameters.get("my-param")).thenReturn(Collections.singletonList("myvalue"));
@@ -417,7 +413,7 @@ public class RequestValidationPolicyTest {
     }
 
     @Test
-    public void shouldValidateQueryParameter_ValidPatternRequiredAndPresent() {
+    void shouldValidateQueryParameter_ValidPatternRequiredAndPresent() {
         // Prepare inbound request
         MultiValueMap<String, String> parameters = mock(MultiValueMap.class);
         when(parameters.get("my-param")).thenReturn(Collections.singletonList("myvalue"));
@@ -449,7 +445,7 @@ public class RequestValidationPolicyTest {
     }
 
     @Test
-    public void shouldNotValidateQueryParameter_NotValidPatternNotRequiredAndPresent() {
+    void shouldNotValidateQueryParameter_NotValidPatternNotRequiredAndPresent() {
         // Prepare inbound request
         MultiValueMap<String, String> parameters = mock(MultiValueMap.class);
         when(parameters.get("my-param")).thenReturn(Collections.singletonList("my1value"));
@@ -481,7 +477,7 @@ public class RequestValidationPolicyTest {
     }
 
     @Test
-    public void shouldNotValidateQueryParameter_NotValidPatternRequiredAndPresent() {
+    void shouldNotValidateQueryParameter_NotValidPatternRequiredAndPresent() {
         // Prepare inbound request
         MultiValueMap<String, String> parameters = mock(MultiValueMap.class);
         when(parameters.get("my-param")).thenReturn(Collections.singletonList("my1value"));
@@ -513,7 +509,7 @@ public class RequestValidationPolicyTest {
     }
 
     @Test
-    public void shouldNotValidateQueryParameter_RuleNotRequiredAndEmptyParameter() {
+    void shouldNotValidateQueryParameter_RuleNotRequiredAndEmptyParameter() {
         // Prepare inbound request
         MultiValueMap<String, String> parameters = mock(MultiValueMap.class);
         when(parameters.get("my-param")).thenReturn(Collections.singletonList(""));
@@ -545,7 +541,7 @@ public class RequestValidationPolicyTest {
     }
 
     @Test
-    public void shouldValidateQueryParameter_inENUM() {
+    void shouldValidateQueryParameter_inENUM() {
         // Prepare inbound request
         MultiValueMap<String, String> parameters = mock(MultiValueMap.class);
         when(parameters.get("my-param")).thenReturn(Collections.singletonList("One"));
@@ -575,7 +571,7 @@ public class RequestValidationPolicyTest {
     }
 
     @Test
-    public void shouldValidateQueryParameter_outENUM() {
+    void shouldValidateQueryParameter_outENUM() {
         // Prepare inbound request
         MultiValueMap<String, String> parameters = mock(MultiValueMap.class);
         when(parameters.get("my-param")).thenReturn(Collections.singletonList("Three"));

--- a/src/test/java/io/gravitee/policy/requestvalidation/validator/DateFormatConstraintValidatorTest.java
+++ b/src/test/java/io/gravitee/policy/requestvalidation/validator/DateFormatConstraintValidatorTest.java
@@ -15,44 +15,41 @@
  */
 package io.gravitee.policy.requestvalidation.validator;
 
-import org.junit.Assert;
-import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 
-/**
- * @author David BRASSELY (david.brassely at graviteesource.com)
- * @author GraviteeSource Team
- */
-public class DateFormatConstraintValidatorTest {
+import org.junit.jupiter.api.Test;
+
+class DateFormatConstraintValidatorTest {
 
     @Test
-    public void shouldNotValidate_nullValue() {
+    void shouldNotValidate_nullValue() {
         DateFormatConstraintValidator validator = new DateFormatConstraintValidator();
         validator.initialize("dd/MM/yyyy");
         boolean valid = validator.isValid(null);
-        Assert.assertFalse(valid);
+        assertThat(valid).isFalse();
     }
 
     @Test
-    public void shouldNotValidate_doesNotRespectPattern() {
+    void shouldNotValidate_doesNotRespectPattern() {
         DateFormatConstraintValidator validator = new DateFormatConstraintValidator();
         validator.initialize("dd/MM/yyyy");
         boolean valid = validator.isValid("31/20/19991");
-        Assert.assertFalse(valid);
+        assertThat(valid).isFalse();
     }
 
     @Test
-    public void shouldValidate_simpleFormat() {
+    void shouldValidate_simpleFormat() {
         DateFormatConstraintValidator validator = new DateFormatConstraintValidator();
         validator.initialize("dd/MM/yyyy");
         boolean valid = validator.isValid("29/02/2012");
-        Assert.assertTrue(valid);
+        assertThat(valid).isTrue();
     }
 
     @Test
-    public void shouldValidate_complexFormat() {
+    void shouldValidate_complexFormat() {
         DateFormatConstraintValidator validator = new DateFormatConstraintValidator();
         validator.initialize("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
         boolean valid = validator.isValid("2001-07-04T12:08:56.235-0700");
-        Assert.assertTrue(valid);
+        assertThat(valid).isTrue();
     }
 }

--- a/src/test/java/io/gravitee/policy/requestvalidation/validator/EnumConstraintValidatorTest.java
+++ b/src/test/java/io/gravitee/policy/requestvalidation/validator/EnumConstraintValidatorTest.java
@@ -15,23 +15,24 @@
  */
 package io.gravitee.policy.requestvalidation.validator;
 
-import org.junit.Assert;
-import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 
-public class EnumConstraintValidatorTest {
+import org.junit.jupiter.api.Test;
+
+class EnumConstraintValidatorTest {
 
     private EnumConstraintValidator enumConstraintValidator;
 
     @Test
-    public void test() {
+    void test() {
         boolean result;
         enumConstraintValidator = new EnumConstraintValidator();
         enumConstraintValidator.initialize("One", "Two");
 
         result = enumConstraintValidator.isValid("One");
-        Assert.assertTrue(result);
+        assertThat(result).isTrue();
 
         result = enumConstraintValidator.isValid("Three");
-        Assert.assertFalse(result);
+        assertThat(result).isFalse();
     }
 }

--- a/src/test/java/io/gravitee/policy/requestvalidation/validator/MailConstraintValidatorTest.java
+++ b/src/test/java/io/gravitee/policy/requestvalidation/validator/MailConstraintValidatorTest.java
@@ -15,52 +15,49 @@
  */
 package io.gravitee.policy.requestvalidation.validator;
 
-import org.junit.Assert;
-import org.junit.Test;
+import static org.assertj.core.api.Assertions.*;
 
-/**
- * @author David BRASSELY (david.brassely at graviteesource.com)
- * @author GraviteeSource Team
- */
-public class MailConstraintValidatorTest {
+import org.junit.jupiter.api.Test;
+
+class MailConstraintValidatorTest {
 
     @Test
-    public void shouldNotValidate_nullValue() {
+    void shouldNotValidate_nullValue() {
         MailConstraintValidator validator = new MailConstraintValidator();
 
         boolean valid = validator.isValid(null);
-        Assert.assertFalse(valid);
+        assertThat(valid).isFalse();
     }
 
     @Test
-    public void shouldNotValidate_emptyValue() {
+    void shouldNotValidate_emptyValue() {
         MailConstraintValidator validator = new MailConstraintValidator();
 
         boolean valid = validator.isValid("");
-        Assert.assertFalse(valid);
+        assertThat(valid).isFalse();
     }
 
     @Test
-    public void shouldNotValidate_badEmail() {
+    void shouldNotValidate_badEmail() {
         MailConstraintValidator validator = new MailConstraintValidator();
 
         boolean valid = validator.isValid("contact@graviteesource");
-        Assert.assertFalse(valid);
+        assertThat(valid).isFalse();
     }
 
     @Test
-    public void shouldValidate() {
+    void shouldValidate() {
         MailConstraintValidator validator = new MailConstraintValidator();
 
         boolean valid = validator.isValid("contact@graviteesource.com");
-        Assert.assertTrue(valid);
+        assertThat(valid).isTrue();
     }
 
     @Test
-    public void shouldValidateEncoded() {
+    void shouldValidateEncoded() {
         MailConstraintValidator validator = new MailConstraintValidator();
 
         boolean valid = validator.isValid("contact%40graviteesource.com");
-        Assert.assertTrue(valid);
+        assertThat(valid).isTrue();
     }
 }

--- a/src/test/java/io/gravitee/policy/requestvalidation/validator/MaxConstraintValidatorTest.java
+++ b/src/test/java/io/gravitee/policy/requestvalidation/validator/MaxConstraintValidatorTest.java
@@ -15,48 +15,45 @@
  */
 package io.gravitee.policy.requestvalidation.validator;
 
-import org.junit.Assert;
-import org.junit.Test;
+import static org.assertj.core.api.Assertions.*;
 
-/**
- * @author David BRASSELY (david.brassely at graviteesource.com)
- * @author GraviteeSource Team
- */
-public class MaxConstraintValidatorTest {
+import org.junit.jupiter.api.Test;
+
+class MaxConstraintValidatorTest {
 
     @Test
-    public void shouldNotValidate_invalidValue() {
+    void shouldNotValidate_invalidValue() {
         MaxConstraintValidator validator = new MaxConstraintValidator();
         validator.initialize("123");
 
         boolean valid = validator.isValid("12.d34");
-        Assert.assertFalse(valid);
+        assertThat(valid).isFalse();
     }
 
     @Test
-    public void shouldNotValidate_invalidMaxValue() {
+    void shouldNotValidate_invalidMaxValue() {
         MaxConstraintValidator validator = new MaxConstraintValidator();
         validator.initialize("123.invalid");
 
         boolean valid = validator.isValid("12.34");
-        Assert.assertFalse(valid);
+        assertThat(valid).isFalse();
     }
 
     @Test
-    public void shouldValidate() {
+    void shouldValidate() {
         MaxConstraintValidator validator = new MaxConstraintValidator();
         validator.initialize("123");
 
         boolean valid = validator.isValid("12.34");
-        Assert.assertTrue(valid);
+        assertThat(valid).isTrue();
     }
 
     @Test
-    public void shouldNotValidate() {
+    void shouldNotValidate() {
         MaxConstraintValidator validator = new MaxConstraintValidator();
         validator.initialize("123");
 
         boolean valid = validator.isValid("1243");
-        Assert.assertFalse(valid);
+        assertThat(valid).isFalse();
     }
 }

--- a/src/test/java/io/gravitee/policy/requestvalidation/validator/MinConstraintValidatorTest.java
+++ b/src/test/java/io/gravitee/policy/requestvalidation/validator/MinConstraintValidatorTest.java
@@ -15,48 +15,45 @@
  */
 package io.gravitee.policy.requestvalidation.validator;
 
-import org.junit.Assert;
-import org.junit.Test;
+import static org.assertj.core.api.Assertions.*;
 
-/**
- * @author David BRASSELY (david.brassely at graviteesource.com)
- * @author GraviteeSource Team
- */
-public class MinConstraintValidatorTest {
+import org.junit.jupiter.api.Test;
+
+class MinConstraintValidatorTest {
 
     @Test
-    public void shouldNotValidate_invalidValue() {
+    void shouldNotValidate_invalidValue() {
         MinConstraintValidator validator = new MinConstraintValidator();
         validator.initialize("123");
 
         boolean valid = validator.isValid("12.d34");
-        Assert.assertFalse(valid);
+        assertThat(valid).isFalse();
     }
 
     @Test
-    public void shouldNotValidate_invalidMaxValue() {
+    void shouldNotValidate_invalidMaxValue() {
         MinConstraintValidator validator = new MinConstraintValidator();
         validator.initialize("123.invalid");
 
         boolean valid = validator.isValid("12.34");
-        Assert.assertFalse(valid);
+        assertThat(valid).isFalse();
     }
 
     @Test
-    public void shouldNotValidate() {
+    void shouldNotValidate() {
         MinConstraintValidator validator = new MinConstraintValidator();
         validator.initialize("123");
 
         boolean valid = validator.isValid("12.34");
-        Assert.assertFalse(valid);
+        assertThat(valid).isFalse();
     }
 
     @Test
-    public void shouldValidate() {
+    void shouldValidate() {
         MinConstraintValidator validator = new MinConstraintValidator();
         validator.initialize("123");
 
         boolean valid = validator.isValid("1243");
-        Assert.assertTrue(valid);
+        assertThat(valid).isTrue();
     }
 }

--- a/src/test/java/io/gravitee/policy/requestvalidation/validator/NotNullConstraintValidatorTest.java
+++ b/src/test/java/io/gravitee/policy/requestvalidation/validator/NotNullConstraintValidatorTest.java
@@ -15,36 +15,33 @@
  */
 package io.gravitee.policy.requestvalidation.validator;
 
-import org.junit.Assert;
-import org.junit.Test;
+import static org.assertj.core.api.Assertions.*;
 
-/**
- * @author David BRASSELY (david.brassely at graviteesource.com)
- * @author GraviteeSource Team
- */
-public class NotNullConstraintValidatorTest {
+import org.junit.jupiter.api.Test;
+
+class NotNullConstraintValidatorTest {
 
     @Test
-    public void shouldNotValidate_nullValue() {
+    void shouldNotValidate_nullValue() {
         NotNullConstraintValidator validator = new NotNullConstraintValidator();
 
         boolean valid = validator.isValid(null);
-        Assert.assertFalse(valid);
+        assertThat(valid).isFalse();
     }
 
     @Test
-    public void shouldNotValidate_emptyValue() {
+    void shouldNotValidate_emptyValue() {
         NotNullConstraintValidator validator = new NotNullConstraintValidator();
 
         boolean valid = validator.isValid("");
-        Assert.assertFalse(valid);
+        assertThat(valid).isFalse();
     }
 
     @Test
-    public void shouldValidate() {
+    void shouldValidate() {
         NotNullConstraintValidator validator = new NotNullConstraintValidator();
 
         boolean valid = validator.isValid("sample");
-        Assert.assertTrue(valid);
+        assertThat(valid).isTrue();
     }
 }

--- a/src/test/java/io/gravitee/policy/requestvalidation/validator/PatternConstraintValidatorTest.java
+++ b/src/test/java/io/gravitee/policy/requestvalidation/validator/PatternConstraintValidatorTest.java
@@ -15,38 +15,35 @@
  */
 package io.gravitee.policy.requestvalidation.validator;
 
-import org.junit.Assert;
-import org.junit.Test;
+import static org.assertj.core.api.Assertions.*;
 
-/**
- * @author Florent CHAMFROY (florent.chamfroy at graviteesource.com)
- * @author GraviteeSource Team
- */
-public class PatternConstraintValidatorTest {
+import org.junit.jupiter.api.Test;
+
+class PatternConstraintValidatorTest {
 
     String pattern = "^test$";
 
     @Test
-    public void shouldNotValidate_nullValue() {
+    void shouldNotValidate_nullValue() {
         PatternConstraintValidator validator = new PatternConstraintValidator();
         validator.initialize(pattern);
         boolean valid = validator.isValid(null);
-        Assert.assertFalse(valid);
+        assertThat(valid).isFalse();
     }
 
     @Test
-    public void shouldNotValidate_doesNotRespectPattern() {
+    void shouldNotValidate_doesNotRespectPattern() {
         PatternConstraintValidator validator = new PatternConstraintValidator();
         validator.initialize(pattern);
         boolean valid = validator.isValid("");
-        Assert.assertFalse(valid);
+        assertThat(valid).isFalse();
     }
 
     @Test
-    public void shouldValidate() {
+    void shouldValidate() {
         PatternConstraintValidator validator = new PatternConstraintValidator();
         validator.initialize(pattern);
         boolean valid = validator.isValid("test");
-        Assert.assertTrue(valid);
+        assertThat(valid).isTrue();
     }
 }

--- a/src/test/java/io/gravitee/policy/requestvalidation/validator/SizeConstraintValidatorTest.java
+++ b/src/test/java/io/gravitee/policy/requestvalidation/validator/SizeConstraintValidatorTest.java
@@ -15,48 +15,45 @@
  */
 package io.gravitee.policy.requestvalidation.validator;
 
-import org.junit.Assert;
-import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 
-/**
- * @author David BRASSELY (david.brassely at graviteesource.com)
- * @author GraviteeSource Team
- */
-public class SizeConstraintValidatorTest {
+import org.junit.jupiter.api.Test;
+
+class SizeConstraintValidatorTest {
 
     @Test
-    public void shouldNotValidate_missingParameter() {
+    void shouldNotValidate_missingParameter() {
         SizeConstraintValidator validator = new SizeConstraintValidator();
         validator.initialize("123");
 
         boolean valid = validator.isValid("lorem ipsum");
-        Assert.assertFalse(valid);
+        assertThat(valid).isFalse();
     }
 
     @Test
-    public void shouldNotValidate_invalidMaxValue() {
+    void shouldNotValidate_invalidMaxValue() {
         SizeConstraintValidator validator = new SizeConstraintValidator();
         validator.initialize("12", "123.invalid");
 
         boolean valid = validator.isValid("lorem ipsum");
-        Assert.assertFalse(valid);
+        assertThat(valid).isFalse();
     }
 
     @Test
-    public void shouldValidate() {
+    void shouldValidate() {
         SizeConstraintValidator validator = new SizeConstraintValidator();
         validator.initialize("1", "23");
 
         boolean valid = validator.isValid("lorem ipsum");
-        Assert.assertTrue(valid);
+        assertThat(valid).isTrue();
     }
 
     @Test
-    public void shouldNotValidate() {
+    void shouldNotValidate() {
         SizeConstraintValidator validator = new SizeConstraintValidator();
         validator.initialize("1", "5");
 
         boolean valid = validator.isValid("lorem ipsum");
-        Assert.assertFalse(valid);
+        assertThat(valid).isFalse();
     }
 }

--- a/src/test/resources/apis/api-with-a-simple-constraint.json
+++ b/src/test/resources/apis/api-with-a-simple-constraint.json
@@ -1,0 +1,52 @@
+{
+    "id": "my-api",
+    "name": "my-api",
+    "gravitee": "2.0.0",
+    "proxy": {
+        "context_path": "/test",
+        "endpoints": [
+            {
+                "name": "default",
+                "target": "http://localhost:8080/endpoint",
+                "http": {
+                    "connectTimeout": 3000,
+                    "readTimeout": 60000
+                }
+            }
+        ]
+    },
+    "flows": [
+        {
+            "name": "flow-1",
+            "methods": ["POST"],
+            "enabled": true,
+            "path-operator": {
+                "path": "/",
+                "operator": "STARTS_WITH"
+            },
+            "pre": [
+                {
+                    "name": "Validate Request",
+                    "description": "",
+                    "enabled": true,
+                    "policy": "policy-request-validation",
+                    "configuration": {
+                        "scope": "REQUEST_CONTENT",
+                        "rules": [
+                            {
+                                "isRequired": true,
+                                "input": "{#jsonPath(#request.content, '$.firstName')}",
+                                "constraint": {
+                                    "type": "NOT_NULL",
+                                    "message": "Missing firstName"
+                                }
+                            }
+                        ],
+                        "status": "400"
+                    }
+                }
+            ],
+            "post": []
+        }
+    ]
+}

--- a/src/test/resources/apis/api-with-multiple-constraints.json
+++ b/src/test/resources/apis/api-with-multiple-constraints.json
@@ -1,0 +1,82 @@
+{
+    "id": "my-api",
+    "name": "my-api",
+    "gravitee": "2.0.0",
+    "proxy": {
+        "context_path": "/test",
+        "endpoints": [
+            {
+                "name": "default",
+                "target": "http://localhost:8080/endpoint",
+                "http": {
+                    "connectTimeout": 3000,
+                    "readTimeout": 60000
+                }
+            }
+        ]
+    },
+    "flows": [
+        {
+            "name": "flow-1",
+            "methods": ["POST"],
+            "enabled": true,
+            "path-operator": {
+                "path": "/",
+                "operator": "STARTS_WITH"
+            },
+            "pre": [
+                {
+                    "name": "Validate Request",
+                    "description": "",
+                    "enabled": true,
+                    "policy": "policy-request-validation",
+                    "configuration": {
+                        "scope": "REQUEST_CONTENT",
+                        "rules": [
+                            {
+                                "isRequired": true,
+                                "input": "{#jsonPath(#request.content, '$.firstName')}",
+                                "constraint": {
+                                    "type": "NOT_NULL",
+                                    "message": "Missing firstName"
+                                }
+                            },
+                            {
+                                "input": "{#jsonPath(#request.content, '$.job')}",
+                                "constraint": {
+                                    "type": "ENUM",
+                                    "parameters": ["DEV", "OPS", "QA"],
+                                    "message": "Invalid job, must be one of `DEV`, `OPS` or `QA`"
+                                }
+                            },
+                            {
+                                "input": "{#jsonPath(#request.content, '$.age')}",
+                                "constraint": {
+                                    "type": "MIN",
+                                    "parameters": ["20"],
+                                    "message": "Invalid age, must be greater than 20"
+                                }
+                            },
+                            {
+                                "input": "{#jsonPath(#request.content, '$.age')}",
+                                "constraint": {
+                                    "type": "MAX",
+                                    "parameters": ["80"],
+                                    "message": "Invalid age, must be lower than 80"
+                                }
+                            },
+                            {
+                                "input": "{#jsonPath(#request.content, '$.email')}",
+                                "constraint": {
+                                    "type": "MAIL"
+                                }
+                            }
+                        ],
+                        "status": "400"
+                    }
+                }
+            ],
+            "post": []
+        }
+    ]
+}


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-896
https://github.com/gravitee-io/issues/issues/8347

**Description**

 - Upgrade all maven plugins
 - Move to gravitee-bom and gravitee-parent 21.0.0
 - Update all dependencies, they were all in `provided` or `test` scope
 - Migrate to JUnit 5
 - Finally, properly return a constraint violation in case of malformed input
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.13.1-APIM-896-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-request-validation/1.13.1-APIM-896-SNAPSHOT/gravitee-policy-request-validation-1.13.1-APIM-896-SNAPSHOT.zip)
  <!-- Version placeholder end -->
