### PR TITLE
Do not use reactive EL method to ensure compatibility with < APIM 3.20

### DIFF
--- a/src/main/java/io/gravitee/policy/requestvalidation/RequestValidationPolicy.java
+++ b/src/main/java/io/gravitee/policy/requestvalidation/RequestValidationPolicy.java
@@ -149,7 +149,9 @@ public class RequestValidationPolicy {
             TemplateEngine templateEngine = executionContext.getTemplateEngine();
             String input = null;
             try {
-                input = templateEngine.eval(rule.getInput(), String.class).blockingGet();
+                // TODO: Use the non deprecated method, but it requires APIM 3.20+ to have an up to date version of the `gravitee-node`
+                // to ensure the correct version of `gravitee-expression-language` + `rxjava` are provided.
+                input = templateEngine.getValue(rule.getInput(), String.class);
             } catch (Exception e) {
                 ConstraintViolation constraintViolation = new ConstraintViolation();
                 constraintViolation.setMessage(


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-1601
https://github.com/gravitee-io/issues/issues/9045

**Description**

Do not use reactive EL method to ensure compatibility with < APIM 3.20 

Added a TODO with info about the breaking change when this code will be updated.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.13.2-APIM-1601-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-request-validation/1.13.2-APIM-1601-SNAPSHOT/gravitee-policy-request-validation-1.13.2-APIM-1601-SNAPSHOT.zip)
  <!-- Version placeholder end -->
