### PR TITLE
fix: add NOT_NULL constraint only if required

### DIFF
--- a/src/main/java/io/gravitee/policy/requestvalidation/swagger/RequestValidationOAIOperationVisitor.java
+++ b/src/main/java/io/gravitee/policy/requestvalidation/swagger/RequestValidationOAIOperationVisitor.java
@@ -53,40 +53,36 @@ public class RequestValidationOAIOperationVisitor implements OAIOperationVisitor
         List<Rule> rules = new ArrayList<>();
 
         if (parameters != null && !parameters.isEmpty()) {
-            parameters.forEach(
-                new Consumer<Parameter>() {
-                    @Override
-                    public void accept(Parameter parameter) {
-                        String in = parameter.getIn();
-                        switch (in) {
-                            case "query":
-                                Rule rule = new Rule();
-                                rule.setInput("{#request.params['" + parameter.getName() + "']}");
+            parameters.forEach(parameter -> {
+                if (parameter.getRequired()) {
+                    String in = parameter.getIn();
+                    switch (in) {
+                        case "query":
+                            Rule rule = new Rule();
+                            rule.setInput("{#request.params['" + parameter.getName() + "']}");
 
-                                Constraint constraint = new Constraint();
-                                constraint.setType(ConstraintType.NOT_NULL);
-                                constraint.setMessage(parameter.getName() + " query parameter is required");
+                            Constraint constraint = new Constraint();
+                            constraint.setType(ConstraintType.NOT_NULL);
+                            constraint.setMessage(parameter.getName() + " query parameter is required");
 
-                                rule.setConstraint(constraint);
+                            rule.setConstraint(constraint);
+                            rules.add(rule);
+                            break;
+                        case "header":
+                            Rule headerRule = new Rule();
+                            headerRule.setInput("{#request.headers['" + parameter.getName() + "'][0]}");
 
-                                rules.add(rule);
-                                break;
-                            case "header":
-                                Rule headerRule = new Rule();
-                                headerRule.setInput("{#request.headers['" + parameter.getName() + "'][0]}");
+                            Constraint headerConstraint = new Constraint();
+                            headerConstraint.setType(ConstraintType.NOT_NULL);
+                            headerConstraint.setMessage(parameter.getName() + " header is required");
 
-                                Constraint headerConstraint = new Constraint();
-                                headerConstraint.setType(ConstraintType.NOT_NULL);
-                                headerConstraint.setMessage(parameter.getName() + " header is required");
+                            headerRule.setConstraint(headerConstraint);
 
-                                headerRule.setConstraint(headerConstraint);
-
-                                rules.add(headerRule);
-                                break;
-                        }
+                            rules.add(headerRule);
+                            break;
                     }
                 }
-            );
+            });
         }
 
         if (!rules.isEmpty()) {

--- a/src/main/java/io/gravitee/policy/requestvalidation/swagger/RequestValidationSwaggerOperationVisitor.java
+++ b/src/main/java/io/gravitee/policy/requestvalidation/swagger/RequestValidationSwaggerOperationVisitor.java
@@ -53,32 +53,34 @@ public class RequestValidationSwaggerOperationVisitor implements SwaggerOperatio
 
         if (parameters != null && !parameters.isEmpty()) {
             parameters.forEach(parameter -> {
-                String in = parameter.getIn();
-                switch (in) {
-                    case "query":
-                        Rule rule = new Rule();
-                        rule.setInput("{#request.params['" + parameter.getName() + "']}");
+                if (parameter.getRequired()) {
+                    String in = parameter.getIn();
+                    switch (in) {
+                        case "query":
+                            Rule rule = new Rule();
+                            rule.setInput("{#request.params['" + parameter.getName() + "']}");
 
-                        Constraint constraint = new Constraint();
-                        constraint.setType(ConstraintType.NOT_NULL);
-                        constraint.setMessage(parameter.getName() + " query parameter is required");
+                            Constraint constraint = new Constraint();
+                            constraint.setType(ConstraintType.NOT_NULL);
+                            constraint.setMessage(parameter.getName() + " query parameter is required");
 
-                        rule.setConstraint(constraint);
+                            rule.setConstraint(constraint);
 
-                        rules.add(rule);
-                        break;
-                    case "header":
-                        Rule headerRule = new Rule();
-                        headerRule.setInput("{#request.headers['" + parameter.getName() + "'][0]}");
+                            rules.add(rule);
+                            break;
+                        case "header":
+                            Rule headerRule = new Rule();
+                            headerRule.setInput("{#request.headers['" + parameter.getName() + "'][0]}");
 
-                        Constraint headerConstraint = new Constraint();
-                        headerConstraint.setType(ConstraintType.NOT_NULL);
-                        headerConstraint.setMessage(parameter.getName() + " header is required");
+                            Constraint headerConstraint = new Constraint();
+                            headerConstraint.setType(ConstraintType.NOT_NULL);
+                            headerConstraint.setMessage(parameter.getName() + " header is required");
 
-                        headerRule.setConstraint(headerConstraint);
+                            headerRule.setConstraint(headerConstraint);
 
-                        rules.add(headerRule);
-                        break;
+                            rules.add(headerRule);
+                            break;
+                    }
                 }
             });
         }


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-3862

**Description**

When importing an OpenAPI file, add NOT_NULL constraint only if the parameter is required.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.15.1-apim-3862-consider-required-parameters-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-request-validation/1.15.1-apim-3862-consider-required-parameters-SNAPSHOT/gravitee-policy-request-validation-1.15.1-apim-3862-consider-required-parameters-SNAPSHOT.zip)
  <!-- Version placeholder end -->
