### PR TITLE
feat: make policy available for mcp proxy on request phase

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,0 +1,52 @@
+#
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+version: "3"
+
+env:
+  APIM_GW_DISTRIBUTION_PATH: "{{.APIM_GW_DISTRIBUTION_PATH }}"
+  APIM_MAPI_DISTRIBUTION_PATH: "{{.APIM_MAPI_DISTRIBUTION_PATH }}"
+
+tasks:
+  build:
+    desc: "Build"
+    cmds:
+      - mvn clean install -DskipTests -Dskip.validation
+
+  copy:
+    desc: "Copy policy"
+    cmds:
+      - cp target/gravitee-policy-request-validation-*.zip ${APIM_GW_DISTRIBUTION_PATH}/plugins
+      - cp target/gravitee-policy-request-validation-*.zip ${APIM_MAPI_DISTRIBUTION_PATH}/plugins
+
+  clean:
+    desc: "Clean"
+    cmds:
+      - rm -f ${APIM_GW_DISTRIBUTION_PATH}/plugins/gravitee-policy-request-validation-*.zip
+      - rm -f ${APIM_MAPI_DISTRIBUTION_PATH}/plugins/gravitee-policy-request-validation-*.zip
+
+  lint:
+    desc: "Lint"
+    cmds:
+      - mvn prettier:write
+
+  all:
+    desc: "Clean, Build and copy"
+    cmds:
+      - task: clean
+      - task: lint
+      - task: build
+      - task: copy

--- a/src/main/resources/plugin.properties
+++ b/src/main/resources/plugin.properties
@@ -8,3 +8,4 @@ category=others
 icon=request-validation.svg
 proxy=REQUEST
 message=REQUEST
+mcp_proxy=REQUEST


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-13230

**Description**

Enable policy for MCP Proxy APIs on request phase

Included taskfile as a bonus :) 
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.16.0-apim-13230-mcp-proxy-on-request-support-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-request-validation/1.16.0-apim-13230-mcp-proxy-on-request-support-SNAPSHOT/gravitee-policy-request-validation-1.16.0-apim-13230-mcp-proxy-on-request-support-SNAPSHOT.zip)
  <!-- Version placeholder end -->
