### PR TITLE
Bump up gravitee parent and gravitee orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,6 @@ setup: true
 orbs:
     gravitee: gravitee-io/gravitee@4.18.1
 
-
 # our single workflow, that triggers the setup job defined above, filters on tag and branches are needed otherwise
 # some workflow and job will not be triggered for tags (default CircleCI behavior)
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 setup: true
 
 orbs:
-    gravitee: gravitee-io/gravitee@4.18.1
+    gravitee: gravitee-io/gravitee@5.9.1
 
 # our single workflow, that triggers the setup job defined above, filters on tag and branches are needed otherwise
 # some workflow and job will not be triggered for tags (default CircleCI behavior)

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,25 +1,25 @@
 {
-  "extends": ["config:base"],
-  "rebaseWhen": "conflicted",
-  "packageRules": [
-    {
-      "matchDatasources": ["orb"],
-      "matchUpdateTypes": ["patch", "minor"],
-      "automerge": true,
-      "automergeType": "branch",
-      "semanticCommitType": "ci"
-    },
-    {
-      "matchDepTypes": ["provided", "test", "build", "import", "parent"],
-      "matchUpdateTypes": ["patch", "minor"],
-      "automerge": true,
-      "automergeType": "branch",
-      "semanticCommitType": "chore"
-    },
-    {
-      "matchDepTypes": ["provided", "test", "build", "import", "parent"],
-      "matchUpdateTypes": ["major"],
-      "semanticCommitType": "chore"
-    }
-  ]
+    "extends": ["config:base"],
+    "rebaseWhen": "conflicted",
+    "packageRules": [
+        {
+            "matchDatasources": ["orb"],
+            "matchUpdateTypes": ["patch", "minor"],
+            "automerge": true,
+            "automergeType": "branch",
+            "semanticCommitType": "ci"
+        },
+        {
+            "matchDepTypes": ["provided", "test", "build", "import", "parent"],
+            "matchUpdateTypes": ["patch", "minor"],
+            "automerge": true,
+            "automergeType": "branch",
+            "semanticCommitType": "chore"
+        },
+        {
+            "matchDepTypes": ["provided", "test", "build", "import", "parent"],
+            "matchUpdateTypes": ["major"],
+            "semanticCommitType": "chore"
+        }
+    ]
 }

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,11 +1,11 @@
 #
-# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+# Copyright © 2015 The Gravitee team (http://gravitee.io)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#         http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -17,36 +17,36 @@
 version: "3"
 
 env:
-  APIM_GW_DISTRIBUTION_PATH: "{{.APIM_GW_DISTRIBUTION_PATH }}"
-  APIM_MAPI_DISTRIBUTION_PATH: "{{.APIM_MAPI_DISTRIBUTION_PATH }}"
+    APIM_GW_DISTRIBUTION_PATH: "{{.APIM_GW_DISTRIBUTION_PATH }}"
+    APIM_MAPI_DISTRIBUTION_PATH: "{{.APIM_MAPI_DISTRIBUTION_PATH }}"
 
 tasks:
-  build:
-    desc: "Build"
-    cmds:
-      - mvn clean install -DskipTests -Dskip.validation
+    build:
+        desc: "Build"
+        cmds:
+            - mvn clean install -DskipTests -Dskip.validation
 
-  copy:
-    desc: "Copy policy"
-    cmds:
-      - cp target/gravitee-policy-request-validation-*.zip ${APIM_GW_DISTRIBUTION_PATH}/plugins
-      - cp target/gravitee-policy-request-validation-*.zip ${APIM_MAPI_DISTRIBUTION_PATH}/plugins
+    copy:
+        desc: "Copy policy"
+        cmds:
+            - cp target/gravitee-policy-request-validation-*.zip ${APIM_GW_DISTRIBUTION_PATH}/plugins
+            - cp target/gravitee-policy-request-validation-*.zip ${APIM_MAPI_DISTRIBUTION_PATH}/plugins
 
-  clean:
-    desc: "Clean"
-    cmds:
-      - rm -f ${APIM_GW_DISTRIBUTION_PATH}/plugins/gravitee-policy-request-validation-*.zip
-      - rm -f ${APIM_MAPI_DISTRIBUTION_PATH}/plugins/gravitee-policy-request-validation-*.zip
+    clean:
+        desc: "Clean"
+        cmds:
+            - rm -f ${APIM_GW_DISTRIBUTION_PATH}/plugins/gravitee-policy-request-validation-*.zip
+            - rm -f ${APIM_MAPI_DISTRIBUTION_PATH}/plugins/gravitee-policy-request-validation-*.zip
 
-  lint:
-    desc: "Lint"
-    cmds:
-      - mvn prettier:write
+    lint:
+        desc: "Lint"
+        cmds:
+            - mvn prettier:write
 
-  all:
-    desc: "Clean, Build and copy"
-    cmds:
-      - task: clean
-      - task: lint
-      - task: build
-      - task: copy
+    all:
+        desc: "Clean, Build and copy"
+        cmds:
+            - task: clean
+            - task: lint
+            - task: build
+            - task: copy

--- a/pom.xml
+++ b/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+    Copyright © 2015 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>21.0.1</version>
+        <version>24.0.2</version>
     </parent>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -34,15 +34,8 @@
     </parent>
 
     <properties>
-        <gravitee-bom.version>4.0.3</gravitee-bom.version>
-        <gravitee-gateway-api.version>2.0.1</gravitee-gateway-api.version>
-        <gravitee-expression-language.version>2.0.1</gravitee-expression-language.version>
-        <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
-        <gravitee-common.version>2.3.0</gravitee-common.version>
-        <swagger-parser.version>2.1.44</swagger-parser.version>
-        <gravitee-gateway.version>3.20.32</gravitee-gateway.version>
+        <gravitee-apim.version>4.8.28</gravitee-apim.version>
 
-        <maven-assembly-plugin.version>3.8.0</maven-assembly-plugin.version>
         <prettier-maven-plugin.version>0.22</prettier-maven-plugin.version>
         <properties-maven-plugin.version>1.3.0</properties-maven-plugin.version>
 
@@ -54,9 +47,9 @@
         <dependencies>
             <!-- Import bom to properly inherit all dependencies -->
             <dependency>
-                <groupId>io.gravitee</groupId>
-                <artifactId>gravitee-bom</artifactId>
-                <version>${gravitee-bom.version}</version>
+                <groupId>io.gravitee.apim</groupId>
+                <artifactId>gravitee-apim-bom</artifactId>
+                <version>${gravitee-apim.version}</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -68,28 +61,24 @@
         <dependency>
             <groupId>io.gravitee.gateway</groupId>
             <artifactId>gravitee-gateway-api</artifactId>
-            <version>${gravitee-gateway-api.version}</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>io.gravitee.policy</groupId>
             <artifactId>gravitee-policy-api</artifactId>
-            <version>${gravitee-policy-api.version}</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>io.gravitee.el</groupId>
             <artifactId>gravitee-expression-language</artifactId>
-            <version>${gravitee-expression-language.version}</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>io.gravitee.common</groupId>
             <artifactId>gravitee-common</artifactId>
-            <version>${gravitee-common.version}</version>
             <scope>provided</scope>
         </dependency>
 
@@ -97,7 +86,6 @@
         <dependency>
             <groupId>io.swagger.parser.v3</groupId>
             <artifactId>swagger-parser</artifactId>
-            <version>${swagger-parser.version}</version>
             <scope>provided</scope>
         </dependency>
 
@@ -150,7 +138,7 @@
         <dependency>
             <groupId>io.gravitee.apim.gateway</groupId>
             <artifactId>gravitee-apim-gateway-tests-sdk</artifactId>
-            <version>${gravitee-gateway.version}</version>
+            <version>${gravitee-apim.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -185,7 +173,6 @@
             </plugin>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>${maven-assembly-plugin.version}</version>
                 <configuration>
                     <appendAssemblyId>false</appendAssemblyId>
                     <descriptors>

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,6 @@
     <properties>
         <gravitee-apim.version>4.8.28</gravitee-apim.version>
 
-        <prettier-maven-plugin.version>0.22</prettier-maven-plugin.version>
         <properties-maven-plugin.version>1.3.0</properties-maven-plugin.version>
 
         <!-- Property used by the publication job in CI-->
@@ -185,22 +184,6 @@
                         <phase>package</phase>
                         <goals>
                             <goal>single</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>com.hubspot.maven.plugins</groupId>
-                <artifactId>prettier-maven-plugin</artifactId>
-                <version>${prettier-maven-plugin.version}</version>
-                <configuration>
-                    <prettierJavaVersion>2.1.0</prettierJavaVersion>
-                </configuration>
-                <executions>
-                    <execution>
-                        <phase>validate</phase>
-                        <goals>
-                            <goal>check</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/src/assembly/policy-assembly.xml
+++ b/src/assembly/policy-assembly.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+    Copyright © 2015 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/policy/requestvalidation/Constraint.java
+++ b/src/main/java/io/gravitee/policy/requestvalidation/Constraint.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/policy/requestvalidation/ConstraintType.java
+++ b/src/main/java/io/gravitee/policy/requestvalidation/ConstraintType.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/policy/requestvalidation/ConstraintValidator.java
+++ b/src/main/java/io/gravitee/policy/requestvalidation/ConstraintValidator.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/policy/requestvalidation/ConstraintValidatorContext.java
+++ b/src/main/java/io/gravitee/policy/requestvalidation/ConstraintValidatorContext.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/policy/requestvalidation/ConstraintViolation.java
+++ b/src/main/java/io/gravitee/policy/requestvalidation/ConstraintViolation.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/policy/requestvalidation/RequestValidationPolicy.java
+++ b/src/main/java/io/gravitee/policy/requestvalidation/RequestValidationPolicy.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/policy/requestvalidation/Rule.java
+++ b/src/main/java/io/gravitee/policy/requestvalidation/Rule.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/policy/requestvalidation/Validator.java
+++ b/src/main/java/io/gravitee/policy/requestvalidation/Validator.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/policy/requestvalidation/configuration/PolicyScope.java
+++ b/src/main/java/io/gravitee/policy/requestvalidation/configuration/PolicyScope.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/policy/requestvalidation/configuration/RequestValidationPolicyConfiguration.java
+++ b/src/main/java/io/gravitee/policy/requestvalidation/configuration/RequestValidationPolicyConfiguration.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/policy/requestvalidation/swagger/RequestValidationOAIOperationVisitor.java
+++ b/src/main/java/io/gravitee/policy/requestvalidation/swagger/RequestValidationOAIOperationVisitor.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/policy/requestvalidation/swagger/RequestValidationSwaggerOperationVisitor.java
+++ b/src/main/java/io/gravitee/policy/requestvalidation/swagger/RequestValidationSwaggerOperationVisitor.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/policy/requestvalidation/validator/AbstractConstraintValidator.java
+++ b/src/main/java/io/gravitee/policy/requestvalidation/validator/AbstractConstraintValidator.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/policy/requestvalidation/validator/DateFormatConstraintValidator.java
+++ b/src/main/java/io/gravitee/policy/requestvalidation/validator/DateFormatConstraintValidator.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/policy/requestvalidation/validator/DefaultValidator.java
+++ b/src/main/java/io/gravitee/policy/requestvalidation/validator/DefaultValidator.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/policy/requestvalidation/validator/EnumConstraintValidator.java
+++ b/src/main/java/io/gravitee/policy/requestvalidation/validator/EnumConstraintValidator.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/policy/requestvalidation/validator/ExpressionBasedValidator.java
+++ b/src/main/java/io/gravitee/policy/requestvalidation/validator/ExpressionBasedValidator.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/policy/requestvalidation/validator/MailConstraintValidator.java
+++ b/src/main/java/io/gravitee/policy/requestvalidation/validator/MailConstraintValidator.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/policy/requestvalidation/validator/MaxConstraintValidator.java
+++ b/src/main/java/io/gravitee/policy/requestvalidation/validator/MaxConstraintValidator.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/policy/requestvalidation/validator/MinConstraintValidator.java
+++ b/src/main/java/io/gravitee/policy/requestvalidation/validator/MinConstraintValidator.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/policy/requestvalidation/validator/NotNullConstraintValidator.java
+++ b/src/main/java/io/gravitee/policy/requestvalidation/validator/NotNullConstraintValidator.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/policy/requestvalidation/validator/NumberConstraintValidator.java
+++ b/src/main/java/io/gravitee/policy/requestvalidation/validator/NumberConstraintValidator.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/policy/requestvalidation/validator/PatternConstraintValidator.java
+++ b/src/main/java/io/gravitee/policy/requestvalidation/validator/PatternConstraintValidator.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/policy/requestvalidation/validator/SizeConstraintValidator.java
+++ b/src/main/java/io/gravitee/policy/requestvalidation/validator/SizeConstraintValidator.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/policy/requestvalidation/validator/StringConstraintValidator.java
+++ b/src/main/java/io/gravitee/policy/requestvalidation/validator/StringConstraintValidator.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -1,263 +1,255 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "type": "object",
-  "additionalProperties": false,
-  "properties" : {
-    "scope" : {
-      "title": "Scope",
-      "description": "Execute policy on 'request' or 'request-content'.",
-      "type" : "string",
-      "default": "REQUEST",
-      "enum" : [ "REQUEST", "REQUEST_CONTENT" ],
-      "deprecated": true
-    },
-    "status" : {
-      "title": "Status Code",
-      "description": "HTTP Status Code send to the consumer in case of validation issues.",
-      "type" : "string",
-      "default": "400",
-      "enum": [
-        "100",
-        "101",
-        "102",
-        "200",
-        "201",
-        "202",
-        "203",
-        "204",
-        "205",
-        "206",
-        "207",
-        "300",
-        "301",
-        "302",
-        "303",
-        "304",
-        "305",
-        "307",
-        "400",
-        "401",
-        "402",
-        "403",
-        "404",
-        "405",
-        "406",
-        "407",
-        "408",
-        "409",
-        "410",
-        "411",
-        "412",
-        "413",
-        "414",
-        "415",
-        "416",
-        "417",
-        "422",
-        "423",
-        "424",
-        "429",
-        "500",
-        "501",
-        "502",
-        "503",
-        "504",
-        "505",
-        "507"
-      ],
-      "x-schema-form": {
-        "type": "select",
-        "titleMap": {
-          "100": "100 - CONTINUE",
-          "101": "101 - SWITCHING_PROTOCOLS",
-          "102": "102 - PROCESSING",
-          "200": "200 - OK",
-          "201": "201 - CREATED",
-          "202": "202 - ACCEPTED",
-          "203": "203 - NON_AUTHORITATIVE_INFORMATION",
-          "204": "204 - NO_CONTENT",
-          "205": "205 - RESET_CONTENT",
-          "206": "206 - PARTIAL_CONTENT",
-          "207": "207 - MULTI_STATUS",
-          "300": "300 - MULTIPLE_CHOICES",
-          "301": "301 - MOVED_PERMANENTLY",
-          "302": "302 - FOUND OR MOVED_TEMPORARILY",
-          "303": "303 - SEE_OTHER",
-          "304": "304 - NOT_MODIFIED",
-          "305": "305 - USE_PROXY",
-          "307": "307 - TEMPORARY_REDIRECT",
-          "400": "400 - BAD_REQUEST",
-          "401": "401 - UNAUTHORIZED",
-          "402": "402 - PAYMENT_REQUIRED",
-          "403": "403 - FORBIDDEN",
-          "404": "404 - NOT_FOUND",
-          "405": "405 - METHOD_NOT_ALLOWED",
-          "406": "406 - NOT_ACCEPTABLE",
-          "407": "407 - PROXY_AUTHENTICATION_REQUIRED",
-          "408": "408 - REQUEST_TIMEOUT",
-          "409": "409 - CONFLICT",
-          "410": "410 - GONE",
-          "411": "411 - LENGTH_REQUIRED",
-          "412": "412 - PRECONDITION_FAILED",
-          "413": "413 - REQUEST_ENTITY_TOO_LARGE",
-          "414": "414 - REQUEST_URI_TOO_LONG",
-          "415": "415 - UNSUPPORTED_MEDIA_TYPE",
-          "416": "416 - REQUESTED_RANGE_NOT_SATISFIABLE",
-          "417": "417 - EXPECTATION_FAILED",
-          "422": "422 - UNPROCESSABLE_ENTITY",
-          "423": "423 - LOCKED",
-          "424": "424 - FAILED_DEPENDENCY",
-          "429": "429 - TOO_MANY_REQUESTS",
-          "500": "500 - INTERNAL_SERVER_ERROR",
-          "501": "501 - NOT_IMPLEMENTED",
-          "502": "502 - BAD_GATEWAY",
-          "503": "503 - SERVICE_UNAVAILABLE",
-          "504": "504 - GATEWAY_TIMEOUT",
-          "505": "505 - HTTP_VERSION_NOT_SUPPORTED",
-          "507": "507 - INSUFFICIENT_STORAGE"
-        }
-      },
-      "gioConfig": {
-        "enumLabelMap": {
-          "100": "100 - CONTINUE",
-          "101": "101 - SWITCHING_PROTOCOLS",
-          "102": "102 - PROCESSING",
-          "200": "200 - OK",
-          "201": "201 - CREATED",
-          "202": "202 - ACCEPTED",
-          "203": "203 - NON_AUTHORITATIVE_INFORMATION",
-          "204": "204 - NO_CONTENT",
-          "205": "205 - RESET_CONTENT",
-          "206": "206 - PARTIAL_CONTENT",
-          "207": "207 - MULTI_STATUS",
-          "300": "300 - MULTIPLE_CHOICES",
-          "301": "301 - MOVED_PERMANENTLY",
-          "302": "302 - FOUND OR MOVED_TEMPORARILY",
-          "303": "303 - SEE_OTHER",
-          "304": "304 - NOT_MODIFIED",
-          "305": "305 - USE_PROXY",
-          "307": "307 - TEMPORARY_REDIRECT",
-          "400": "400 - BAD_REQUEST",
-          "401": "401 - UNAUTHORIZED",
-          "402": "402 - PAYMENT_REQUIRED",
-          "403": "403 - FORBIDDEN",
-          "404": "404 - NOT_FOUND",
-          "405": "405 - METHOD_NOT_ALLOWED",
-          "406": "406 - NOT_ACCEPTABLE",
-          "407": "407 - PROXY_AUTHENTICATION_REQUIRED",
-          "408": "408 - REQUEST_TIMEOUT",
-          "409": "409 - CONFLICT",
-          "410": "410 - GONE",
-          "411": "411 - LENGTH_REQUIRED",
-          "412": "412 - PRECONDITION_FAILED",
-          "413": "413 - REQUEST_ENTITY_TOO_LARGE",
-          "414": "414 - REQUEST_URI_TOO_LONG",
-          "415": "415 - UNSUPPORTED_MEDIA_TYPE",
-          "416": "416 - REQUESTED_RANGE_NOT_SATISFIABLE",
-          "417": "417 - EXPECTATION_FAILED",
-          "422": "422 - UNPROCESSABLE_ENTITY",
-          "423": "423 - LOCKED",
-          "424": "424 - FAILED_DEPENDENCY",
-          "429": "429 - TOO_MANY_REQUESTS",
-          "500": "500 - INTERNAL_SERVER_ERROR",
-          "501": "501 - NOT_IMPLEMENTED",
-          "502": "502 - BAD_GATEWAY",
-          "503": "503 - SERVICE_UNAVAILABLE",
-          "504": "504 - GATEWAY_TIMEOUT",
-          "505": "505 - HTTP_VERSION_NOT_SUPPORTED",
-          "507": "507 - INSUFFICIENT_STORAGE"
-        }
-      }
-    },
-    "rules" : {
-      "type" : "array",
-      "title" : "Rules",
-      "items" : {
-        "type" : "object",
-        "title" : "Rule",
-        "properties" : {
-          "input" : {
-            "type" : "string",
-            "title": "Field value",
-            "description": "The input value to validate. (supports EL)",
-            "x-schema-form": {
-              "expression-language": true
-            }
-          },
-          "isRequired" : {
-            "type" : "boolean",
-            "title": "Required",
-            "description": "If true, check the pattern always. If false check the pattern, only if this one is present in the request.",
-            "default": true
-          },
-          "constraint" : {
-            "type" : "object",
-            "title" : "Constraint",
-            "properties" : {
-              "type" : {
-                "type" : "string",
-                "enum" : [ "NOT_NULL", "MIN", "MAX", "MAIL", "DATE", "PATTERN", "SIZE", "ENUM" ],
-                "default": "NOT_NULL",
-                "title": "Type",
-                "description": "The constraint rule to apply to the field value.",
-                "x-schema-form": {
-                  "type": "select",
-                  "titleMap": {
-                    "NOT_NULL": "NOT_NULL: Field value is required",
-                    "MIN": "MIN: Field number value is greater or equals than parameter",
-                    "MAX": "MAX: Field number value is lower or equals than parameter",
-                    "MAIL": "MAIL: Field value is a valid email",
-                    "PATTERN": "PATTERN: Field value is valid according to the pattern parameter",
-                    "DATE": "DATE: Field value is valid according to the date format parameter",
-                    "SIZE": "Field value length is between min and max parameters",
-                    "ENUM": "ENUM: Field value included in ENUM"
-                  }
-                },
-                "gioConfig": {
-                  "enumLabelMap": {
-                    "NOT_NULL": "NOT_NULL: Field value is required",
-                    "MIN": "MIN: Field number value is greater or equals than parameter",
-                    "MAX": "MAX: Field number value is lower or equals than parameter",
-                    "MAIL": "MAIL: Field value is a valid email",
-                    "PATTERN": "PATTERN: Field value is valid according to the pattern parameter",
-                    "DATE": "DATE: Field value is valid according to the date format parameter",
-                    "SIZE": "Field value length is between min and max parameters",
-                    "ENUM": "ENUM: Field value included in ENUM"
-                  }
-                }
-              },
-              "parameters" : {
-                "type" : "array",
-                "title": "Parameters",
-                "items" : {
-                  "type" : "string",
-                  "title": "Parameter",
-                  "description": "Must be defined for MIN, MAX, DATE or PATTERN constraints. (supports EL)",
-                  "x-schema-form": {
-                    "expression-language": true
-                  }
-                }
-              },
-              "message" : {
-                "type" : "string",
-                "title": "Message template",
-                "description": "Set a message template to override the default one. (Example: <i>'%s' must be higher or equals to '%s'</i>)"
-              }
-            },
-            "required": [
-              "type"
-            ]
-          }
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+        "scope": {
+            "title": "Scope",
+            "description": "Execute policy on 'request' or 'request-content'.",
+            "type": "string",
+            "default": "REQUEST",
+            "enum": ["REQUEST", "REQUEST_CONTENT"],
+            "deprecated": true
         },
-        "required": [
-          "input",
-          "constraint"
-        ]
-      }
-    }
-  },
-  "required": [
-    "status",
-    "rules"
-  ]
+        "status": {
+            "title": "Status Code",
+            "description": "HTTP Status Code send to the consumer in case of validation issues.",
+            "type": "string",
+            "default": "400",
+            "enum": [
+                "100",
+                "101",
+                "102",
+                "200",
+                "201",
+                "202",
+                "203",
+                "204",
+                "205",
+                "206",
+                "207",
+                "300",
+                "301",
+                "302",
+                "303",
+                "304",
+                "305",
+                "307",
+                "400",
+                "401",
+                "402",
+                "403",
+                "404",
+                "405",
+                "406",
+                "407",
+                "408",
+                "409",
+                "410",
+                "411",
+                "412",
+                "413",
+                "414",
+                "415",
+                "416",
+                "417",
+                "422",
+                "423",
+                "424",
+                "429",
+                "500",
+                "501",
+                "502",
+                "503",
+                "504",
+                "505",
+                "507"
+            ],
+            "x-schema-form": {
+                "type": "select",
+                "titleMap": {
+                    "100": "100 - CONTINUE",
+                    "101": "101 - SWITCHING_PROTOCOLS",
+                    "102": "102 - PROCESSING",
+                    "200": "200 - OK",
+                    "201": "201 - CREATED",
+                    "202": "202 - ACCEPTED",
+                    "203": "203 - NON_AUTHORITATIVE_INFORMATION",
+                    "204": "204 - NO_CONTENT",
+                    "205": "205 - RESET_CONTENT",
+                    "206": "206 - PARTIAL_CONTENT",
+                    "207": "207 - MULTI_STATUS",
+                    "300": "300 - MULTIPLE_CHOICES",
+                    "301": "301 - MOVED_PERMANENTLY",
+                    "302": "302 - FOUND OR MOVED_TEMPORARILY",
+                    "303": "303 - SEE_OTHER",
+                    "304": "304 - NOT_MODIFIED",
+                    "305": "305 - USE_PROXY",
+                    "307": "307 - TEMPORARY_REDIRECT",
+                    "400": "400 - BAD_REQUEST",
+                    "401": "401 - UNAUTHORIZED",
+                    "402": "402 - PAYMENT_REQUIRED",
+                    "403": "403 - FORBIDDEN",
+                    "404": "404 - NOT_FOUND",
+                    "405": "405 - METHOD_NOT_ALLOWED",
+                    "406": "406 - NOT_ACCEPTABLE",
+                    "407": "407 - PROXY_AUTHENTICATION_REQUIRED",
+                    "408": "408 - REQUEST_TIMEOUT",
+                    "409": "409 - CONFLICT",
+                    "410": "410 - GONE",
+                    "411": "411 - LENGTH_REQUIRED",
+                    "412": "412 - PRECONDITION_FAILED",
+                    "413": "413 - REQUEST_ENTITY_TOO_LARGE",
+                    "414": "414 - REQUEST_URI_TOO_LONG",
+                    "415": "415 - UNSUPPORTED_MEDIA_TYPE",
+                    "416": "416 - REQUESTED_RANGE_NOT_SATISFIABLE",
+                    "417": "417 - EXPECTATION_FAILED",
+                    "422": "422 - UNPROCESSABLE_ENTITY",
+                    "423": "423 - LOCKED",
+                    "424": "424 - FAILED_DEPENDENCY",
+                    "429": "429 - TOO_MANY_REQUESTS",
+                    "500": "500 - INTERNAL_SERVER_ERROR",
+                    "501": "501 - NOT_IMPLEMENTED",
+                    "502": "502 - BAD_GATEWAY",
+                    "503": "503 - SERVICE_UNAVAILABLE",
+                    "504": "504 - GATEWAY_TIMEOUT",
+                    "505": "505 - HTTP_VERSION_NOT_SUPPORTED",
+                    "507": "507 - INSUFFICIENT_STORAGE"
+                }
+            },
+            "gioConfig": {
+                "enumLabelMap": {
+                    "100": "100 - CONTINUE",
+                    "101": "101 - SWITCHING_PROTOCOLS",
+                    "102": "102 - PROCESSING",
+                    "200": "200 - OK",
+                    "201": "201 - CREATED",
+                    "202": "202 - ACCEPTED",
+                    "203": "203 - NON_AUTHORITATIVE_INFORMATION",
+                    "204": "204 - NO_CONTENT",
+                    "205": "205 - RESET_CONTENT",
+                    "206": "206 - PARTIAL_CONTENT",
+                    "207": "207 - MULTI_STATUS",
+                    "300": "300 - MULTIPLE_CHOICES",
+                    "301": "301 - MOVED_PERMANENTLY",
+                    "302": "302 - FOUND OR MOVED_TEMPORARILY",
+                    "303": "303 - SEE_OTHER",
+                    "304": "304 - NOT_MODIFIED",
+                    "305": "305 - USE_PROXY",
+                    "307": "307 - TEMPORARY_REDIRECT",
+                    "400": "400 - BAD_REQUEST",
+                    "401": "401 - UNAUTHORIZED",
+                    "402": "402 - PAYMENT_REQUIRED",
+                    "403": "403 - FORBIDDEN",
+                    "404": "404 - NOT_FOUND",
+                    "405": "405 - METHOD_NOT_ALLOWED",
+                    "406": "406 - NOT_ACCEPTABLE",
+                    "407": "407 - PROXY_AUTHENTICATION_REQUIRED",
+                    "408": "408 - REQUEST_TIMEOUT",
+                    "409": "409 - CONFLICT",
+                    "410": "410 - GONE",
+                    "411": "411 - LENGTH_REQUIRED",
+                    "412": "412 - PRECONDITION_FAILED",
+                    "413": "413 - REQUEST_ENTITY_TOO_LARGE",
+                    "414": "414 - REQUEST_URI_TOO_LONG",
+                    "415": "415 - UNSUPPORTED_MEDIA_TYPE",
+                    "416": "416 - REQUESTED_RANGE_NOT_SATISFIABLE",
+                    "417": "417 - EXPECTATION_FAILED",
+                    "422": "422 - UNPROCESSABLE_ENTITY",
+                    "423": "423 - LOCKED",
+                    "424": "424 - FAILED_DEPENDENCY",
+                    "429": "429 - TOO_MANY_REQUESTS",
+                    "500": "500 - INTERNAL_SERVER_ERROR",
+                    "501": "501 - NOT_IMPLEMENTED",
+                    "502": "502 - BAD_GATEWAY",
+                    "503": "503 - SERVICE_UNAVAILABLE",
+                    "504": "504 - GATEWAY_TIMEOUT",
+                    "505": "505 - HTTP_VERSION_NOT_SUPPORTED",
+                    "507": "507 - INSUFFICIENT_STORAGE"
+                }
+            }
+        },
+        "rules": {
+            "type": "array",
+            "title": "Rules",
+            "items": {
+                "type": "object",
+                "title": "Rule",
+                "properties": {
+                    "input": {
+                        "type": "string",
+                        "title": "Field value",
+                        "description": "The input value to validate. (supports EL)",
+                        "x-schema-form": {
+                            "expression-language": true
+                        }
+                    },
+                    "isRequired": {
+                        "type": "boolean",
+                        "title": "Required",
+                        "description": "If true, check the pattern always. If false check the pattern, only if this one is present in the request.",
+                        "default": true
+                    },
+                    "constraint": {
+                        "type": "object",
+                        "title": "Constraint",
+                        "properties": {
+                            "type": {
+                                "type": "string",
+                                "enum": ["NOT_NULL", "MIN", "MAX", "MAIL", "DATE", "PATTERN", "SIZE", "ENUM"],
+                                "default": "NOT_NULL",
+                                "title": "Type",
+                                "description": "The constraint rule to apply to the field value.",
+                                "x-schema-form": {
+                                    "type": "select",
+                                    "titleMap": {
+                                        "NOT_NULL": "NOT_NULL: Field value is required",
+                                        "MIN": "MIN: Field number value is greater or equals than parameter",
+                                        "MAX": "MAX: Field number value is lower or equals than parameter",
+                                        "MAIL": "MAIL: Field value is a valid email",
+                                        "PATTERN": "PATTERN: Field value is valid according to the pattern parameter",
+                                        "DATE": "DATE: Field value is valid according to the date format parameter",
+                                        "SIZE": "Field value length is between min and max parameters",
+                                        "ENUM": "ENUM: Field value included in ENUM"
+                                    }
+                                },
+                                "gioConfig": {
+                                    "enumLabelMap": {
+                                        "NOT_NULL": "NOT_NULL: Field value is required",
+                                        "MIN": "MIN: Field number value is greater or equals than parameter",
+                                        "MAX": "MAX: Field number value is lower or equals than parameter",
+                                        "MAIL": "MAIL: Field value is a valid email",
+                                        "PATTERN": "PATTERN: Field value is valid according to the pattern parameter",
+                                        "DATE": "DATE: Field value is valid according to the date format parameter",
+                                        "SIZE": "Field value length is between min and max parameters",
+                                        "ENUM": "ENUM: Field value included in ENUM"
+                                    }
+                                }
+                            },
+                            "parameters": {
+                                "type": "array",
+                                "title": "Parameters",
+                                "items": {
+                                    "type": "string",
+                                    "title": "Parameter",
+                                    "description": "Must be defined for MIN, MAX, DATE or PATTERN constraints. (supports EL)",
+                                    "x-schema-form": {
+                                        "expression-language": true
+                                    }
+                                }
+                            },
+                            "message": {
+                                "type": "string",
+                                "title": "Message template",
+                                "description": "Set a message template to override the default one. (Example: <i>'%s' must be higher or equals to '%s'</i>)"
+                            }
+                        },
+                        "required": ["type"]
+                    }
+                },
+                "required": ["input", "constraint"]
+            }
+        }
+    },
+    "required": ["status", "rules"]
 }

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -13,7 +13,7 @@
         },
         "status": {
             "title": "Status Code",
-            "description": "HTTP Status Code send to the consumer in case of validation issues.",
+            "description": "HTTP Status Code sent to the consumer in case of validation issues.",
             "type": "string",
             "default": "400",
             "enum": [

--- a/src/test/java/io/gravitee/policy/requestvalidation/RequestValidationPolicyIntegrationTest.java
+++ b/src/test/java/io/gravitee/policy/requestvalidation/RequestValidationPolicyIntegrationTest.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/io/gravitee/policy/requestvalidation/RequestValidationPolicyIntegrationTest.java
+++ b/src/test/java/io/gravitee/policy/requestvalidation/RequestValidationPolicyIntegrationTest.java
@@ -144,10 +144,9 @@ class RequestValidationPolicyIntegrationTest extends AbstractPolicyTest<RequestV
                 JsonObject body = new JsonObject(bufferBody.toString());
                 assertThat(body.getString("message")).isEqualTo("Request is not valid according to constraint rules");
                 assertThat(body.getJsonArray("constraints").size()).isEqualTo(1);
-                assertThat(body.getJsonArray("constraints").getString(0))
-                    .isEqualTo(
-                        "Unable to evaluate expression: {#jsonPath(#request.content, '$.firstName')} -> It might be related to an invalid request body"
-                    );
+                assertThat(body.getJsonArray("constraints").getString(0)).isEqualTo(
+                    "Unable to evaluate expression: {#jsonPath(#request.content, '$.firstName')} -> It might be related to an invalid request body"
+                );
                 return true;
             })
             .assertNoErrors();

--- a/src/test/java/io/gravitee/policy/requestvalidation/RequestValidationPolicyTest.java
+++ b/src/test/java/io/gravitee/policy/requestvalidation/RequestValidationPolicyTest.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/io/gravitee/policy/requestvalidation/RequestValidationPolicyTest.java
+++ b/src/test/java/io/gravitee/policy/requestvalidation/RequestValidationPolicyTest.java
@@ -300,24 +300,23 @@ class RequestValidationPolicyTest {
         policy.onRequest(request, response, executionContext, policyChain);
 
         // Check results
-        verify(policyChain)
-            .failWith(
-                argThat(result -> {
-                    ArrayList<String> violationsTemp = (ArrayList<String>) result.parameters().get("violations");
-                    ArrayDeque<String> violations = new ArrayDeque<>(violationsTemp);
+        verify(policyChain).failWith(
+            argThat(result -> {
+                ArrayList<String> violationsTemp = (ArrayList<String>) result.parameters().get("violations");
+                ArrayDeque<String> violations = new ArrayDeque<>(violationsTemp);
 
-                    rulesMap
-                        .entrySet()
-                        .stream()
-                        .forEach(ruleMapEntry -> {
-                            ConstraintValidator validator = ruleMapEntry.getValue();
-                            String violation = violations.pollFirst();
-                            assertThat(Pattern.matches(validatorRegexMap.get(validator.getClass()), violation)).isTrue();
-                        });
+                rulesMap
+                    .entrySet()
+                    .stream()
+                    .forEach(ruleMapEntry -> {
+                        ConstraintValidator validator = ruleMapEntry.getValue();
+                        String violation = violations.pollFirst();
+                        assertThat(Pattern.matches(validatorRegexMap.get(validator.getClass()), violation)).isTrue();
+                    });
 
-                    return result.statusCode() == HttpStatusCode.BAD_REQUEST_400;
-                })
-            );
+                return result.statusCode() == HttpStatusCode.BAD_REQUEST_400;
+            })
+        );
     }
 
     @Test

--- a/src/test/java/io/gravitee/policy/requestvalidation/validator/DateFormatConstraintValidatorTest.java
+++ b/src/test/java/io/gravitee/policy/requestvalidation/validator/DateFormatConstraintValidatorTest.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/io/gravitee/policy/requestvalidation/validator/EnumConstraintValidatorTest.java
+++ b/src/test/java/io/gravitee/policy/requestvalidation/validator/EnumConstraintValidatorTest.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/io/gravitee/policy/requestvalidation/validator/MailConstraintValidatorTest.java
+++ b/src/test/java/io/gravitee/policy/requestvalidation/validator/MailConstraintValidatorTest.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/io/gravitee/policy/requestvalidation/validator/MaxConstraintValidatorTest.java
+++ b/src/test/java/io/gravitee/policy/requestvalidation/validator/MaxConstraintValidatorTest.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/io/gravitee/policy/requestvalidation/validator/MinConstraintValidatorTest.java
+++ b/src/test/java/io/gravitee/policy/requestvalidation/validator/MinConstraintValidatorTest.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/io/gravitee/policy/requestvalidation/validator/NotNullConstraintValidatorTest.java
+++ b/src/test/java/io/gravitee/policy/requestvalidation/validator/NotNullConstraintValidatorTest.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/io/gravitee/policy/requestvalidation/validator/PatternConstraintValidatorTest.java
+++ b/src/test/java/io/gravitee/policy/requestvalidation/validator/PatternConstraintValidatorTest.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/io/gravitee/policy/requestvalidation/validator/SizeConstraintValidatorTest.java
+++ b/src/test/java/io/gravitee/policy/requestvalidation/validator/SizeConstraintValidatorTest.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
**Description**

Bump up the Gravitee parent and the Gravitee orb to unblock publishing the policy release on Nexus
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.17.0-bump-up-gravitee-parent-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-request-validation/1.17.0-bump-up-gravitee-parent-SNAPSHOT/gravitee-policy-request-validation-1.17.0-bump-up-gravitee-parent-SNAPSHOT.zip)
  <!-- Version placeholder end -->
